### PR TITLE
Попытка починить проводку на ДС-2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -3407,6 +3407,9 @@
 	pixel_x = -2
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "nG" = (


### PR DESCRIPTION
Автобилдер кабеля в коде всё ещё несколько сломан, но под провода (которые подключаются к АПЦ и СМЕСам, заставляет их не спавниться вовсе.